### PR TITLE
Fixed capital in Laravel provider and alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Find the `providers` key in your `app/config/app.php` and register the Statsd Se
 ```php
     'providers' => array(
         // ...
-        'League\Statsd\Laravel\Provider\StatsdServiceProvider',
+        'League\StatsD\Laravel\Provider\StatsdServiceProvider',
     )
 ```
 
@@ -37,7 +37,7 @@ Find the `aliases` key in your `app/config/app.php` and add the Statsd Facade Al
 ```php
     'aliases' => array(
         // ...
-        'Statsd' => 'League\Statsd\Laravel\Facade\StatsdFacade',
+        'Statsd' => 'League\StatsD\Laravel\Facade\StatsdFacade',
     )
 ```
 


### PR DESCRIPTION
The namespacing in the serviceprovider and the facade is 'StatsD' and not 'Statsd'. Therefor you get an "Class 'League\Statsd\Laravel\Provider\StatsdServiceProvider' not found" error.