### PR TITLE
Allow optional disabling of connection exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ $statsd2 = StatsD\Client::instance('server2')->configure(array(...));
 The StatsD client wait for `ini_get('default_socket_timeout')` seconds when opening the socket by default. To reduce
 this timeout, add `'timeout' => <float>` to your config.
 
+The StatsD client will throw a `ConnectionException` if it is unable to send data to the StatsD server. You may choose
+to disable these exceptions and log a PHP warning instead if you wish. To do so, include the following in your config:
+
+```
+    'throwConnectionExceptions' => false
+```
+
+If omitted, this option defaults to `true`.
+
 ### Counters
 
 ```php

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -4,7 +4,6 @@ namespace League\StatsD\Test;
 
 class ConnectionTest extends TestCase
 {
-
     /**
      * Non-integer ports are not acceptable
      * @expectedException League\StatsD\Exception\ConnectionException
@@ -23,8 +22,32 @@ class ConnectionTest extends TestCase
             'host' => 'localhost',
             'timeout' => 123
         ));
-
         $this->assertAttributeSame(123, 'timeout', $this->client);
+    }
+
+    public function testCanBeConfiguredNotToThrowConnectionExceptions()
+    {
+        $this->client->configure(array(
+            'host' => 'hostdoesnotexiststalleverlol.stupidtld',
+            'throwConnectionExceptions' => false
+        ));
+        $handlerInvoked = false;
+
+        set_error_handler(function ($errno, $errstr, $errfile, $errline, $errcontext) use (&$handlerInvoked) {
+            $handlerInvoked = true;
+
+            $this->assertSame(E_USER_WARNING, $errno);
+            $this->assertSame(
+                'StatsD server connection failed (udp://hostdoesnotexiststalleverlol.stupidtld:8125)',
+                $errstr
+            );
+            $this->assertSame(realpath(__DIR__ . '/../src/Client.php'), $errfile);
+        }, E_USER_WARNING);
+
+        $this->client->increment('test');
+        restore_error_handler();
+
+        $this->assertTrue($handlerInvoked);
     }
 
     public function testTimeoutDefaultsToPhpIniDefaultSocketTimeout()

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -33,16 +33,21 @@ class ConnectionTest extends TestCase
         ));
         $handlerInvoked = false;
 
-        set_error_handler(function ($errno, $errstr, $errfile, $errline, $errcontext) use (&$handlerInvoked) {
-            $handlerInvoked = true;
+        $testCase = $this;
 
-            $this->assertSame(E_USER_WARNING, $errno);
-            $this->assertSame(
-                'StatsD server connection failed (udp://hostdoesnotexiststalleverlol.stupidtld:8125)',
-                $errstr
-            );
-            $this->assertSame(realpath(__DIR__ . '/../src/Client.php'), $errfile);
-        }, E_USER_WARNING);
+        set_error_handler(
+            function ($errno, $errstr, $errfile, $errline, $errcontext) use ($testCase, &$handlerInvoked) {
+                $handlerInvoked = true;
+
+                $testCase->assertSame(E_USER_WARNING, $errno);
+                $testCase->assertSame(
+                    'StatsD server connection failed (udp://hostdoesnotexiststalleverlol.stupidtld:8125)',
+                    $errstr
+                );
+                $testCase->assertSame(realpath(__DIR__ . '/../src/Client.php'), $errfile);
+            },
+            E_USER_WARNING
+        );
 
         $this->client->increment('test');
         restore_error_handler();


### PR DESCRIPTION
Metrics gathering on my project is a welcome bonus, but not a critical feature, so I don't want a page load to fail if it can't connect to StatsD. I also don't want to wrap every invocation with:

```php
try {
    // ... do statsd stuff
} (catch ConnectionException $e) {
    // do nothing
}
```

I *could* just write a wrapper to do all that transparently, but I think "just log a warning and keep loading the page" is a common enough use case, and making the exception throwing configurable would be a helpful contribution.

The `throwConnectionExceptions` configuration setting is completely optional, and it will throw exceptions by default like it does now (so there is no BC issue).