### PR TITLE
Added a configurable timeout value for the StatsD Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ $statsd1 = StatsD\Client::instance('server1')->configure(array(...));
 $statsd2 = StatsD\Client::instance('server2')->configure(array(...));
 ```
 
+The StatsD client wait for `ini_get('default_socket_timeout')` seconds when opening the socket by default. To reduce
+this timeout, add `'timeout' => <float>` to your config.
+
 ### Counters
 
 ```php

--- a/src/Client.php
+++ b/src/Client.php
@@ -54,6 +54,12 @@ class Client
      */
     protected $namespace = '';
 
+    /**
+     * Timeout for creating the socket connection
+     * @var null|float
+     */
+    protected $timeout;
+
 
     /**
      * Singleton Reference
@@ -77,6 +83,10 @@ class Client
     public function __construct($instance_id = null)
     {
         $this->instance_id = $instance_id ?: uniqid();
+
+        if (empty($this->timeout)) {
+            $this->timeout = ini_get('default_socket_timeout');
+        }
     }
 
 
@@ -110,6 +120,9 @@ class Client
         }
         if (isset($options['namespace'])) {
             $this->namespace = $options['namespace'];
+        }
+        if (isset($options['timeout'])) {
+            $this->timeout = $options['timeout'];
         }
         return $this;
     }
@@ -266,7 +279,7 @@ class Client
     protected function send(array $data)
     {
 
-        $socket = @fsockopen('udp://' . $this->host, $this->port, $errno, $errstr);
+        $socket = @fsockopen('udp://' . $this->host, $this->port, $errno, $errstr, $this->timeout);
         if (! $socket) {
             throw new ConnectionException($this, '(' . $errno . ') ' . $errstr);
         }

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -17,5 +17,18 @@ class ConnectionTest extends TestCase
         $this->client->increment('test');
     }
 
+    public function testTimeoutSettingIsUsedWhenCreatingSocketIfProvided()
+    {
+        $this->client->configure(array(
+            'host' => 'localhost',
+            'timeout' => 123
+        ));
 
+        $this->assertAttributeSame(123, 'timeout', $this->client);
+    }
+
+    public function testTimeoutDefaultsToPhpIniDefaultSocketTimeout()
+    {
+        $this->assertAttributeSame(ini_get('default_socket_timeout'), 'timeout', $this->client);
+    }
 }


### PR DESCRIPTION
This PR adds a configurable timeout to prevent long delays when attempting to open the socket connection. If not specified, it will default to the `default_socket_timeout` setting in `php.ini`, which is the normal behavior if no `$timeout` is passed to `fsockopen(...)`.

Note that while I've added tests for this, it's not possible to test that the `$timeout` value is actually being passed to `fsockopen` unless:

(a) the `League\StatsD\Test` namespace is changed to `League\StatsD`, which will allow me to use the "namespace global function hack" to verify that `fsockopen` was called with the correct timeout, or (b) Travis needs to install the [uopz](http://php.net/manual/en/book.uopz.php) Pecl module in order to "mock" the global `fsockopen(...)` function.

I'd be happy to send a PR if you wish to go either route, but otherwise, this PR covers all new lines of code.