### PR TITLE
use late-static binding to new up client

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -69,7 +69,7 @@ class Client
     public static function instance($name = 'default')
     {
         if (! isset(self::$instances[$name])) {
-            self::$instances[$name] = new Client($name);
+            self::$instances[$name] = new static($name);
         }
         return self::$instances[$name];
     }

--- a/tests/LateStaticClient.php
+++ b/tests/LateStaticClient.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace League\StatsD\Test;
+
+class LateStaticClient extends \League\StatsD\Client
+{
+
+}

--- a/tests/LateStaticClientTest.php
+++ b/tests/LateStaticClientTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace League\StatsD\Test;
+
+class LateStaticClientTest extends TestCase
+{
+
+    public function testStaticInstance()
+    {
+        $client = new LateStaticClient();
+        $instance = LateStaticClient::instance();
+        $this->assertTrue($instance instanceof LateStaticClient);
+    }
+
+}


### PR DESCRIPTION
**Type**: Refactor

## Summary ##
In our application the need arose to extend the `League\StatsD\Client` class.

In doing so we discovered that using the `Client::instance()` method returned the wrong instance of the `Client` class. (this is because the instance method calls `new Client()` within itself).

The fix for this is to use a late-static binding call `new static($name)`, which should return the extended instance of the class.

I've included an example extended class as well as a test.
Any feedback is appreciated.

Cheers.