### PR TITLE
`throwConnectionExceptions` wasn't getting passed through service providers to Laravel et al

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -5,5 +5,7 @@ return [
 
 	'port' => 8125,
 
-	'namespace' => ''
+	'namespace' => '',
+
+	'throwConnectionExceptions' => true,
 ];

--- a/src/Laravel/Provider/StatsdServiceProvider.php
+++ b/src/Laravel/Provider/StatsdServiceProvider.php
@@ -53,6 +53,9 @@ class StatsdServiceProvider extends ServiceProvider
                 if (isset($app['config']['statsd.namespace'])) {
                     $options['namespace'] = $app['config']['statsd.namespace'];
                 }
+                if (isset($app['config']['statsd.timeout'])) {
+                    $options['timeout'] = $app['config']['statsd.timeout'];
+                }
                 if (isset($app['config']['statsd.throwConnectionExceptions'])) {
                     $options['throwConnectionExceptions'] = $app['config']['statsd.throwConnectionExceptions'];
                 }

--- a/src/Laravel/Provider/StatsdServiceProvider.php
+++ b/src/Laravel/Provider/StatsdServiceProvider.php
@@ -53,6 +53,9 @@ class StatsdServiceProvider extends ServiceProvider
                 if (isset($app['config']['statsd.namespace'])) {
                     $options['namespace'] = $app['config']['statsd.namespace'];
                 }
+                if (isset($app['config']['statsd.throwConnectionExceptions'])) {
+                    $options['throwConnectionExceptions'] = $app['config']['statsd.throwConnectionExceptions'];
+                }
 
                 // Create
                 $statsd = new Statsd();

--- a/src/Laravel5/Provider/StatsdServiceProvider.php
+++ b/src/Laravel5/Provider/StatsdServiceProvider.php
@@ -56,6 +56,9 @@ class StatsdServiceProvider extends ServiceProvider
                 if (isset($app['config']['statsd.namespace'])) {
                     $options['namespace'] = $app['config']['statsd.namespace'];
                 }
+                if (isset($app['config']['statsd.throwConnectionExceptions'])) {
+                    $options['throwConnectionExceptions'] = $app['config']['statsd.throwConnectionExceptions'];
+                }
 
                 // Create
                 $statsd = new Statsd();
@@ -63,7 +66,7 @@ class StatsdServiceProvider extends ServiceProvider
                 return $statsd;
             }
         );
-        
+
         $this->app->bind('League\StatsD\Client', function ($app) {
             return $app['statsd'];
         });

--- a/src/Laravel5/Provider/StatsdServiceProvider.php
+++ b/src/Laravel5/Provider/StatsdServiceProvider.php
@@ -56,6 +56,9 @@ class StatsdServiceProvider extends ServiceProvider
                 if (isset($app['config']['statsd.namespace'])) {
                     $options['namespace'] = $app['config']['statsd.namespace'];
                 }
+                if (isset($app['config']['statsd.timeout'])) {
+                    $options['timeout'] = $app['config']['statsd.timeout'];
+                }
                 if (isset($app['config']['statsd.throwConnectionExceptions'])) {
                     $options['throwConnectionExceptions'] = $app['config']['statsd.throwConnectionExceptions'];
                 }

--- a/src/Silex/Provider/StatsdServiceProvider.php
+++ b/src/Silex/Provider/StatsdServiceProvider.php
@@ -34,12 +34,12 @@ class StatsdServiceProvider implements ServiceProviderInterface
                 if (isset($app['statsd.namespace'])) {
                     $options['namespace'] = $app['statsd.namespace'];
                 }
-                if (isset($app['config']['statsd.timeout'])) {
-                    $options['timeout'] = $app['config']['statsd.timeout'];
+                if (isset($app['statsd.timeout'])) {
+                    $options['timeout'] = $app['statsd.timeout'];
                 }
-                if (isset($app['config']['statsd.throwConnectionExceptions'])) {
-                    $options['throwConnectionExceptions'] = $app['config']['statsd.throwConnectionExceptions'];
-                }                
+                if (isset($app['statsd.throwConnectionExceptions'])) {
+                    $options['throwConnectionExceptions'] = $app['statsd.throwConnectionExceptions'];
+                }
 
                 // Create
                 $statsd = new StatsdClient();

--- a/src/Silex/Provider/StatsdServiceProvider.php
+++ b/src/Silex/Provider/StatsdServiceProvider.php
@@ -34,6 +34,12 @@ class StatsdServiceProvider implements ServiceProviderInterface
                 if (isset($app['statsd.namespace'])) {
                     $options['namespace'] = $app['statsd.namespace'];
                 }
+                if (isset($app['config']['statsd.timeout'])) {
+                    $options['timeout'] = $app['config']['statsd.timeout'];
+                }
+                if (isset($app['config']['statsd.throwConnectionExceptions'])) {
+                    $options['throwConnectionExceptions'] = $app['config']['statsd.throwConnectionExceptions'];
+                }                
 
                 // Create
                 $statsd = new StatsdClient();


### PR DESCRIPTION
As a follow up to #25 I noticed that no matter what `throwConnectionExceptions` was set to, Laravel still threw one, so this fixed that.

Specifically to Laravel, the `trigger_error` call will stop execution, meaning even with `throwConnectionExceptions` switched off, any issue sending the packet will still trigger a full shutdown of the framework.

I'm not sure how best to adjust this behaviour without affecting non Laravel users.