### PR TITLE
Fix isset issue for php7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
 
 before_script:
   - composer self-update

--- a/src/Laravel/Provider/StatsdServiceProvider.php
+++ b/src/Laravel/Provider/StatsdServiceProvider.php
@@ -40,31 +40,9 @@ class StatsdServiceProvider extends ServiceProvider
      */
     protected function registerStatsD()
     {
-        $this->app['statsd'] = $this->app->share(
-            function ($app) {
-                // Set Default host and port
-                $options = array();
-                if (isset($app['config']['statsd.host'])) {
-                    $options['host'] = $app['config']['statsd.host'];
-                }
-                if (isset($app['config']['statsd.port'])) {
-                    $options['port'] = $app['config']['statsd.port'];
-                }
-                if (isset($app['config']['statsd.namespace'])) {
-                    $options['namespace'] = $app['config']['statsd.namespace'];
-                }
-                if (isset($app['config']['statsd.timeout'])) {
-                    $options['timeout'] = $app['config']['statsd.timeout'];
-                }
-                if (isset($app['config']['statsd.throwConnectionExceptions'])) {
-                    $options['throwConnectionExceptions'] = $app['config']['statsd.throwConnectionExceptions'];
-                }
-
-                // Create
-                $statsd = new Statsd();
-                $statsd->configure($options);
-                return $statsd;
-            }
-        );
+        $this->app['statsd'] = $this->app->share(function ($app) {
+            $statsd = new Statsd();
+            return $statsd->configure(isset($app['config']['statsd']) ? $app['config']['statsd'] : array());
+        });
     }
 }

--- a/src/Laravel5/Provider/StatsdServiceProvider.php
+++ b/src/Laravel5/Provider/StatsdServiceProvider.php
@@ -44,27 +44,9 @@ class StatsdServiceProvider extends ServiceProvider
     protected function registerStatsD()
     {
         $this->app['statsd'] = $this->app->share(function () {
-            // Set Default host and port
-            $config = config('statsd');
-            $options = array();
-            if (isset($config['host'])) {
-                $options['host'] = $config['host'];
-            }
-            if (isset($config['port'])) {
-                $options['port'] = $config['port'];
-            }
-            if (isset($config['namespace'])) {
-                $options['namespace'] = $config['namespace'];
-            }
-            if (isset($config['timeout'])) {
-                $options['timeout'] = $config['timeout'];
-            }
-            if (isset($config['throwConnectionExceptions'])) {
-                $options['throwConnectionExceptions'] = $config['throwConnectionExceptions'];
-            }
-
-            // Create
-            return (new Statsd())->configure($options);
+            $statsd = new Statsd();
+            $statsd->configure(config('statsd'));
+            return $statsd;
         });
 
         $this->app->bind('League\StatsD\Client', function ($app) {

--- a/src/Laravel5/Provider/StatsdServiceProvider.php
+++ b/src/Laravel5/Provider/StatsdServiceProvider.php
@@ -43,32 +43,29 @@ class StatsdServiceProvider extends ServiceProvider
      */
     protected function registerStatsD()
     {
-        $this->app['statsd'] = $this->app->share(
-            function ($app) {
-                // Set Default host and port
-                $options = array();
-                if (isset($app['config']['statsd.host'])) {
-                    $options['host'] = $app['config']['statsd.host'];
-                }
-                if (isset($app['config']['statsd.port'])) {
-                    $options['port'] = $app['config']['statsd.port'];
-                }
-                if (isset($app['config']['statsd.namespace'])) {
-                    $options['namespace'] = $app['config']['statsd.namespace'];
-                }
-                if (isset($app['config']['statsd.timeout'])) {
-                    $options['timeout'] = $app['config']['statsd.timeout'];
-                }
-                if (isset($app['config']['statsd.throwConnectionExceptions'])) {
-                    $options['throwConnectionExceptions'] = $app['config']['statsd.throwConnectionExceptions'];
-                }
-
-                // Create
-                $statsd = new Statsd();
-                $statsd->configure($options);
-                return $statsd;
+        $this->app['statsd'] = $this->app->share(function () {
+            // Set Default host and port
+            $config = config('statsd');
+            $options = array();
+            if (isset($config['host'])) {
+                $options['host'] = $config['host'];
             }
-        );
+            if (isset($config['port'])) {
+                $options['port'] = $config['port'];
+            }
+            if (isset($config['namespace'])) {
+                $options['namespace'] = $config['namespace'];
+            }
+            if (isset($config['timeout'])) {
+                $options['timeout'] = $config['timeout'];
+            }
+            if (isset($config['throwConnectionExceptions'])) {
+                $options['throwConnectionExceptions'] = $config['throwConnectionExceptions'];
+            }
+
+            // Create
+            return (new Statsd())->configure($options);
+        });
 
         $this->app->bind('League\StatsD\Client', function ($app) {
             return $app['statsd'];

--- a/src/Silex/Provider/StatsdServiceProvider.php
+++ b/src/Silex/Provider/StatsdServiceProvider.php
@@ -20,34 +20,10 @@ class StatsdServiceProvider implements ServiceProviderInterface
      */
     public function register(Application $app)
     {
-        $app['statsd'] = $app->share(
-            function () use ($app) {
-
-                // Set Default host and port
-                $options = array();
-                if (isset($app['statsd.host'])) {
-                    $options['host'] = $app['statsd.host'];
-                }
-                if (isset($app['statsd.port'])) {
-                    $options['port'] = $app['statsd.port'];
-                }
-                if (isset($app['statsd.namespace'])) {
-                    $options['namespace'] = $app['statsd.namespace'];
-                }
-                if (isset($app['statsd.timeout'])) {
-                    $options['timeout'] = $app['statsd.timeout'];
-                }
-                if (isset($app['statsd.throwConnectionExceptions'])) {
-                    $options['throwConnectionExceptions'] = $app['statsd.throwConnectionExceptions'];
-                }
-
-                // Create
-                $statsd = new StatsdClient();
-                $statsd->configure($options);
-                return $statsd;
-
-            }
-        );
+        $app['statsd'] = $app->share(function () use ($app) {
+            $statsd = new StatsdClient();
+            return $statsd->configure($app['statsd']);
+        });
     }
 
 


### PR DESCRIPTION
This is a strange issue, so bear with me. With PHP 7.0.10-2 on Ubuntu 16.04.1, isset always returns false in the Laravel 5 provider. This doesn't happen on PHP 5.6 or PHP7 on Windows (I checked). For example, even if a host is specified, this line always evaluates to false:

https://github.com/thephpleague/statsd/blob/master/src/Laravel5/Provider/StatsdServiceProvider.php#L50

I used the config() global function in the Laravel 5 provider to get the config. I also just passed the config on through without checking if the parameters exist because you do that anyway in the configure function. The global config function isn't available in Laravel 4, or, obviously, Silex, so I couldn't had it there. I did, however, remove the unneeded isset checking and passed the config through like I did in the Laravel 5 provider.
