### PR TITLE
Fix #34. Evaluation of indirect expressions in PHP7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
 
 before_script:
   - composer self-update

--- a/src/Laravel/Provider/StatsdServiceProvider.php
+++ b/src/Laravel/Provider/StatsdServiceProvider.php
@@ -44,20 +44,26 @@ class StatsdServiceProvider extends ServiceProvider
             function ($app) {
                 // Set Default host and port
                 $options = array();
-                if (isset($app['config']['statsd.host'])) {
-                    $options['host'] = $app['config']['statsd.host'];
+                $config  = $app['config'];
+
+                if (isset($config['statsd.host'])) {
+                    $options['host'] = $config['statsd.host'];
                 }
-                if (isset($app['config']['statsd.port'])) {
-                    $options['port'] = $app['config']['statsd.port'];
+
+                if (isset($config['statsd.port'])) {
+                    $options['port'] = $config['statsd.port'];
                 }
-                if (isset($app['config']['statsd.namespace'])) {
-                    $options['namespace'] = $app['config']['statsd.namespace'];
+
+                if (isset($config['statsd.namespace'])) {
+                    $options['namespace'] = $config['statsd.namespace'];
                 }
-                if (isset($app['config']['statsd.timeout'])) {
-                    $options['timeout'] = $app['config']['statsd.timeout'];
+
+                if (isset($config['statsd.timeout'])) {
+                    $options['timeout'] = $config['statsd.timeout'];
                 }
-                if (isset($app['config']['statsd.throwConnectionExceptions'])) {
-                    $options['throwConnectionExceptions'] = $app['config']['statsd.throwConnectionExceptions'];
+
+                if (isset($config['statsd.throwConnectionExceptions'])) {
+                    $options['throwConnectionExceptions'] = (boolean) $config['statsd.throwConnectionExceptions'];
                 }
 
                 // Create

--- a/src/Laravel5/Provider/StatsdServiceProvider.php
+++ b/src/Laravel5/Provider/StatsdServiceProvider.php
@@ -47,20 +47,26 @@ class StatsdServiceProvider extends ServiceProvider
             function ($app) {
                 // Set Default host and port
                 $options = array();
-                if (isset($app['config']['statsd.host'])) {
-                    $options['host'] = $app['config']['statsd.host'];
+                $config  = $app['config'];
+
+                if (isset($config['statsd.host'])) {
+                    $options['host'] = $config['statsd.host'];
                 }
-                if (isset($app['config']['statsd.port'])) {
-                    $options['port'] = $app['config']['statsd.port'];
+
+                if (isset($config['statsd.port'])) {
+                    $options['port'] = $config['statsd.port'];
                 }
-                if (isset($app['config']['statsd.namespace'])) {
-                    $options['namespace'] = $app['config']['statsd.namespace'];
+
+                if (isset($config['statsd.namespace'])) {
+                    $options['namespace'] = $config['statsd.namespace'];
                 }
-                if (isset($app['config']['statsd.timeout'])) {
-                    $options['timeout'] = $app['config']['statsd.timeout'];
+
+                if (isset($config['statsd.timeout'])) {
+                    $options['timeout'] = $config['statsd.timeout'];
                 }
-                if (isset($app['config']['statsd.throwConnectionExceptions'])) {
-                    $options['throwConnectionExceptions'] = $app['config']['statsd.throwConnectionExceptions'];
+
+                if (isset($config['statsd.throwConnectionExceptions'])) {
+                    $options['throwConnectionExceptions'] = (boolean) $config['statsd.throwConnectionExceptions'];
                 }
 
                 // Create


### PR DESCRIPTION
This should fix laravel service providers for PHP7.
It looks like the problem not in "[__isset](https://github.com/thephpleague/statsd/pull/32)" or something, the problem is in changed [evaluation of indirect expressions](http://php.net/manual/en/migration70.incompatible.php#migration70.incompatible.variable-handling).