### PR TITLE
Laravel 5.4 support

### DIFF
--- a/src/Laravel5/Provider/StatsdServiceProvider.php
+++ b/src/Laravel5/Provider/StatsdServiceProvider.php
@@ -47,7 +47,7 @@ class StatsdServiceProvider extends ServiceProvider
      */
     protected function registerStatsD()
     {
-        $this->app['statsd'] = $this->app->share(
+        $this->app->singleton('statsd',
             function ($app) {
                 // Set Default host and port
                 $options = array();


### PR DESCRIPTION
Share method no longer exists in Laravel 5.4 application container
We should use singleton instead.