### PR TITLE
Update Silex Service Provider to match newest Silex interface

### DIFF
--- a/src/Silex/Provider/StatsdServiceProvider.php
+++ b/src/Silex/Provider/StatsdServiceProvider.php
@@ -3,7 +3,7 @@
 namespace League\StatsD\Silex\Provider;
 
 use Silex\Application;
-use Silex\ServiceProviderInterface;
+use Pimple\ServiceProviderInterface;
 use League\StatsD\Client as StatsdClient;
 
 /**

--- a/src/Silex/Provider/StatsdServiceProvider.php
+++ b/src/Silex/Provider/StatsdServiceProvider.php
@@ -3,6 +3,7 @@
 namespace League\StatsD\Silex\Provider;
 
 use Silex\Application;
+use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 use League\StatsD\Client as StatsdClient;
 
@@ -18,10 +19,9 @@ class StatsdServiceProvider implements ServiceProviderInterface
      * Register Service Provider
      * @param Application $app Silex application instance
      */
-    public function register(Application $app)
+    public function register(Container $app)
     {
-        $app['statsd'] = $app->share(
-            function () use ($app) {
+        $app['statsd'] =  function () use ($app) {
 
                 // Set Default host and port
                 $options = array();
@@ -46,8 +46,7 @@ class StatsdServiceProvider implements ServiceProviderInterface
                 $statsd->configure($options);
                 return $statsd;
 
-            }
-        );
+            };
     }
 
 


### PR DESCRIPTION
Hi,

I don't know if it was by choice, but the current version of silex use Pimple as container and the interface needed some update.