### PR TITLE
Updated Silex to ~2.0.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require-dev": {
-        "silex/silex": "~1.0",
+        "silex/silex": "~2.0",
         "phpunit/phpunit": "~4.0"
     },
     "autoload": {

--- a/src/Silex/Provider/StatsdServiceProvider.php
+++ b/src/Silex/Provider/StatsdServiceProvider.php
@@ -3,8 +3,10 @@
 namespace League\StatsD\Silex\Provider;
 
 use Silex\Application;
-use Silex\ServiceProviderInterface;
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
 use League\StatsD\Client as StatsdClient;
+use Symfony\Component\HttpKernel\Tests\Controller;
 
 /**
  * StatsD Service provider for Silex
@@ -16,12 +18,11 @@ class StatsdServiceProvider implements ServiceProviderInterface
 
     /**
      * Register Service Provider
-     * @param Application $app Silex application instance
+     * @param Container $app Pimple container instance
      */
-    public function register(Application $app)
+    public function register(Container $app)
     {
-        $app['statsd'] = $app->share(
-            function () use ($app) {
+        $app['statsd'] =  function () use ($app) {
 
                 // Set Default host and port
                 $options = array();
@@ -46,8 +47,7 @@ class StatsdServiceProvider implements ServiceProviderInterface
                 $statsd->configure($options);
                 return $statsd;
 
-            }
-        );
+            };
     }
 
 


### PR DESCRIPTION
Silex 2 has been release last year and there was some changes that this library doesn't support.

I don't know if there's a particular reason as why it wasn't updated, but I'm proposing this pull request to update the Silex version to ~2.0.

The ServiceProviderInterface has change namespace in version ~2.0. It's now:
use Pimple\ServiceProviderInterface;

Updated the StatsdServiceProvider to reflect that change