### PR TITLE
Fix PHPUnit test cases and configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require-dev": {
         "silex/silex": "~2.0",
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "~5.7"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,7 @@
 <phpunit colors="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" stopOnError="false" stopOnFailure="false" stopOnIncomplete="false" stopOnSkipped="false" bootstrap="vendor/autoload.php">
     <testsuites>
         <testsuite name="League StatsD Test Suite">
-            <directory suffix="Test.php">tests</directory>
+            <directory>tests</directory>
         </testsuite>
     </testsuites>
     <filter>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,10 +1,9 @@
 <?php
 
 namespace League\StatsD\Test;
-use PHPUnit_Framework_TestCase;
 use League\StatsD\Client;
 
-class TestCase extends PHPUnit_Framework_TestCase
+class TestCase extends \PHPUnit\Framework\TestCase
 {
 
     protected $client;


### PR DESCRIPTION
This PR fixes issue #46 

On PHP7 and PHPUnit 6, this repo was having trouble running the tests, mainly because PHPUnit wasn't able to find any tests because the TestCase class was extending an old version of TestCase

Bumped the PHPUnit version and extended the correct class. Since this repo aims to support +5.6 (based on the travis configuration file) it doesn't make sense to use an old version of PHPUnit