### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ php:
   - 7.2
 
 before_script:
-  - composer self-update
   - composer install
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,16 @@
         }
     ],
     "require-dev": {
-        "silex/silex": "~2.0",
-        "phpunit/phpunit": "~5.7"
+        "silex/silex": "^2.0",
+        "phpunit/phpunit": "^5.7 || ^6.5"
     },
     "autoload": {
         "psr-4": {
-            "League\\StatsD\\": "src",
+            "League\\StatsD\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "League\\StatsD\\Test\\": "tests"
         }
     },

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -10,7 +10,7 @@ class ClientTest extends TestCase
     public function testNewInstance()
     {
         $client = new Client();
-        $this->assertTrue($client instanceof Client);
+        $this->assertInstanceOf(Client::class, $client);
         $this->assertRegExp('/^StatsD\\\Client::\[[a-zA-Z0-9]+\]$/', (String) $client);
     }
 
@@ -18,7 +18,7 @@ class ClientTest extends TestCase
     public function testStaticInstance()
     {
         $client1 = Client::instance('instance1');
-        $this->assertTrue($client1 instanceof Client);
+        $this->assertInstanceOf(Client::class, $client1);
         $client2 = Client::instance('instance2');
         $client3 = Client::instance('instance1');
         $this->assertEquals('StatsD\Client::[instance2]', (String) $client2);

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -15,7 +15,7 @@ class ExceptionTest extends TestCase
             throw new ConnectionException($this->client, 'Could not connect');
         } catch (ConnectionException $e) {
             $client = $e->getInstance();
-            $this->assertTrue($client instanceof Client);
+            $this->assertInstanceOf(Client::class, $client);
             $this->assertEquals('Could not connect', $e->getMessage());
             return;
         }
@@ -29,7 +29,7 @@ class ExceptionTest extends TestCase
             throw new ConfigurationException($this->client, 'Configuration error');
         } catch (ConfigurationException $e) {
             $client = $e->getInstance();
-            $this->assertTrue($client instanceof Client);
+            $this->assertInstanceOf(Client::class, $client);
             $this->assertEquals('Configuration error', $e->getMessage());
             return;
         }

--- a/tests/LaravelFacadeTest.php
+++ b/tests/LaravelFacadeTest.php
@@ -3,6 +3,7 @@
 namespace League\StatsD\Test;
 
 use League\StatsD\Laravel\Facade\StatsdFacade as Statsd;
+use League\StatsD\Client;
 
 class LaravelFacadeTest extends LaravelTestCase
 {
@@ -16,6 +17,6 @@ class LaravelFacadeTest extends LaravelTestCase
 
         // Get an instance of a client (S3) via its facade
         $statsd = Statsd::instance();
-        $this->assertInstanceOf('League\StatsD\Client', $statsd);
+        $this->assertInstanceOf(Client::class, $statsd);
     }
 } 

--- a/tests/LaravelProviderTest.php
+++ b/tests/LaravelProviderTest.php
@@ -13,7 +13,7 @@ class LaravelProviderTest extends LaravelTestCase
         $this->setupServiceProvider($app);
 
         // Make sure is the right instance type
-        $this->assertTrue($app['statsd'] instanceof Client);
+        $this->assertInstanceOf(Client::class, $app['statsd']);
 
         // Make sure configuration is sorted
         $this->assertEquals('localhost', $app['statsd']->getHost());

--- a/tests/LaravelTestCase.php
+++ b/tests/LaravelTestCase.php
@@ -13,7 +13,7 @@ class LaravelTestCase extends TestCase
     public function setUp()
     {
         parent::setUp();
-        if (!class_exists('\Illuminate\Foundation\Application')) {
+        if (!class_exists(Application::class)) {
             $this->markTestSkipped("Can't test Laravel integration without Illuminate");
         }
     }

--- a/tests/LateStaticClientTest.php
+++ b/tests/LateStaticClientTest.php
@@ -9,7 +9,7 @@ class LateStaticClientTest extends TestCase
     {
         $client = new LateStaticClient();
         $instance = LateStaticClient::instance();
-        $this->assertTrue($instance instanceof LateStaticClient);
+        $this->assertInstanceOf(LateStaticClient::class, $instance);
     }
 
 }

--- a/tests/SilexProviderTest.php
+++ b/tests/SilexProviderTest.php
@@ -15,7 +15,9 @@ class SilexProviderTest extends TestCase
         $app->register(new StatsdServiceProvider(), array(
             'statsd.host' => 'localhost',
             'statsd.port' => 7890,
-            'statsd.namespace' => 'test_namespace'
+            'statsd.namespace' => 'test_namespace',
+            'statsd.timeout' => 10,
+            'statsd.throwConnectionExceptions' => false,
         ));
 
         // Make sure is the right instance type


### PR DESCRIPTION
# Changed log
- Use the ```assertInstanceOf``` instead of using ```instanceof``` with ```assertTrue```.
- Set the multiple PHPUnit versions to support the different PHP versions.
- Remove the ```composer selfupdate``` command because this command is executed by default in Travis CI build.