### PR TITLE
add possibility to pass float value for gauge metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ $statsd->increment('web.clicks', 1, 0.5);
 
 ```php
 $statsd->gauge('api.logged_in_users', 123456);
+$statsd->gauge('api.logged_in_users', 987654.321);
 ```
 
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -324,7 +324,7 @@ class Client
     /**
      * Gauges
      * @param  string $metric Metric to gauge
-     * @param  int $value Set the value of the gauge
+     * @param  int|float $value Set the value of the gauge
      * @param  array $tags A list of metric tags values
      * @return $this
      * @throws ConnectionException

--- a/tests/GaugeTest.php
+++ b/tests/GaugeTest.php
@@ -11,4 +11,10 @@ class GaugeTest extends TestCase
         $this->assertEquals('test_metric:456|g', $this->client->getLastMessage());
     }
 
+    public function testGaugeWithFloatValue()
+    {
+        $this->client->gauge('test_metric', 456.789);
+        $this->assertEquals('test_metric:456.789|g', $this->client->getLastMessage());
+    }
+
 }


### PR DESCRIPTION
A gauge metric may contain a float value.
This PR only update the PHPDoc as the code can already work for it. Without it, code analyzers may throw errors on it.