### PR TITLE
Propagate ConnectionException message via trigger_error()

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -418,7 +418,12 @@ class Client
                 throw $e;
             } else {
                 trigger_error(
-                    sprintf('StatsD server connection failed (udp://%s:%d)', $this->host, $this->port),
+                    sprintf(
+                        'StatsD server connection failed (udp://%s:%d): %s',
+                        $this->host,
+                        $this->port,
+                        $e->getMessage()
+                    ),
                     E_USER_WARNING
                 );
             }

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -40,7 +40,7 @@ class ConnectionTest extends TestCase
                 $handlerInvoked = true;
 
                 $testCase->assertSame(E_USER_WARNING, $errno);
-                $testCase->assertSame(
+                $testCase->assertContains(
                     'StatsD server connection failed (udp://hostdoesnotexiststalleverlol.stupidtld:8125)',
                     $errstr
                 );


### PR DESCRIPTION
## What & Why?
As it presently stands, the `ConnectionException` is thrown when opening a socket fails and contains the system-level error code and message. This information, however, is only accessible if the `throwConnectionExceptions` flag is set and the original exception is propagated to the consumer. If the exception is disabled, then a user warning will be created using the `trigger_error()` function, which unfortunately does not carry an information from the exception, leading to inability to properly debug connection issues. With this change the original exception message will be appended to the produced warning.

### Before
```
StatsD server connection failed (udp://hostdoesnotexiststalleverlol.stupidtld:8125)
```

### After
```
StatsD server connection failed (udp://hostdoesnotexiststalleverlol.stupidtld:8125): (0) php_network_getaddresses: getaddrinfo failed: Name or service not known
```