### PR TITLE
Ability to use TCP connections.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Latest Stable Version](https://poser.pugx.org/league/statsd/v/stable.png)](https://packagist.org/packages/league/statsd)
 
 
-A library for working with StatsD in PHP.
+A framework-agnostic library for working with StatsD in PHP.
 
 
 
@@ -53,6 +53,23 @@ to disable these exceptions and log a PHP warning instead if you wish. To do so,
 If omitted, this option defaults to `true`.
 
 
+### Configuring to use TCP
+
+***Attention!** With a TCP port your application will slow down. Use it if you know what you are doing.*
+
+By default, StatsD client use UDP port. In most cases you won't need anything else. But it's also possible to use
+TCP port. Just provide the desired scheme name in your configuration.
+
+```php
+$statsd = new League\StatsD\Client();
+$statsd->configure([
+    'scheme' => 'tcp',
+    'host' => '127.0.0.1',
+    'port' => 8125
+]);
+```
+
+TCP connection allows you to send a huge bunches of metrics in single call. It also has delivery guarantees.
 
 ### Counters
 
@@ -144,7 +161,7 @@ Find the `aliases` key in your `app/config/app.php` and add the Statsd Facade Al
         'Statsd' => 'League\StatsD\Laravel\Facade\StatsdFacade',
     ]
 ```
-### Laravel 5.x
+### Laravel 5.x and greater
 
 If you are using Laravel `>=5.5`, statsd uses [package discovery](https://laravel.com/docs/5.5/packages#package-discovery) to automatically register the service provider and facade.
 
@@ -185,6 +202,7 @@ Package Configuration
 In your `.env` file, add the configuration:
 
 ```php
+STATSD_SCHEME=udp
 STATSD_HOST=127.0.0.1
 STATSD_PORT=8125
 STATSD_NAMESPACE=

--- a/config/statsd.php
+++ b/config/statsd.php
@@ -1,7 +1,9 @@
 <?php
 
 return [
-	'host' => env('STATSD_HOST', '127.0.0.1'),
+    'scheme' => env('STATSD_SCHEME', 'udp'),
+
+    'host' => env('STATSD_HOST', '127.0.0.1'),
 
 	'port' => env('STATSD_PORT', 8125),
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,4 +16,8 @@
         </testsuite>
     </testsuites>
 
+    <php>
+        <env name="STATSD_TCP_ADDRESS" value=""/>
+    </php>
+
 </phpunit>

--- a/src/Client.php
+++ b/src/Client.php
@@ -68,6 +68,9 @@ class Client implements StatsDClient
         }
     }
 
+    /**
+     * String representation of the instance
+     */
     public function __toString(): string
     {
         return 'StatsD\Client::[' . $this->instanceId . ']';
@@ -112,16 +115,31 @@ class Client implements StatsDClient
         return $this;
     }
 
+    /**
+     * Get server host
+     *
+     * @return string
+     */
     public function getHost(): string
     {
         return $this->host;
     }
 
+    /**
+     * Get server port
+     *
+     * @return int
+     */
     public function getPort(): int
     {
         return $this->port;
     }
 
+    /**
+     * Get metrics namespace
+     *
+     * @return string
+     */
     public function getNamespace(): string
     {
         return $this->namespace;
@@ -169,7 +187,7 @@ class Client implements StatsDClient
      *
      * @param string|array $metrics    Metric(s) to decrement
      * @param int          $delta      Value to increment the metric by
-     * @param float          $sampleRate Sample rate of metric
+     * @param float        $sampleRate Sample rate of metric
      * @param array        $tags       A list of metric tags values
      *
      * @throws ConnectionException
@@ -258,13 +276,12 @@ class Client implements StatsDClient
         $this->timing($metric, $time, $tags);
     }
 
-
     /**
      * Gauges
      *
-     * @param string $metric Metric to gauge
+     * @param string    $metric Metric to gauge
      * @param int|float $value  Set the value of the gauge
-     * @param array  $tags   A list of metric tags values
+     * @param array     $tags   A list of metric tags values
      *
      * @throws ConnectionException
      */
@@ -276,9 +293,9 @@ class Client implements StatsDClient
     /**
      * Sets - count the number of unique values passed to a key
      *
-     * @param string $metric
-     * @param mixed $value
-     * @param array $tags A list of metric tags values
+     * @param string $metric Metric name
+     * @param mixed  $value  Value to count
+     * @param array  $tags   A list of metric tags values
      *
      * @throws ConnectionException
      */
@@ -288,13 +305,16 @@ class Client implements StatsDClient
     }
 
     /**
-     * @return resource
-     * @throws ConnectionException
+     * Get stream to server
+     *
+     * @return resource File pointer representing the connection to the server
+     *
+     * @throws ConnectionException If there is a connection problem with the host
      */
     protected function getSocket()
     {
         if (! $this->socket) {
-            $this->socket = @fsockopen('udp://' . $this->host, $this->port, $errno, $errstr, $this->timeout);
+            $this->socket = @fsockopen($this->scheme . '://' . $this->host, $this->port, $errno, $errstr, $this->timeout);
             if (! $this->socket) {
                 throw new ConnectionException($this, '(' . $errno . ') ' . $errstr);
             }
@@ -303,6 +323,13 @@ class Client implements StatsDClient
         return $this->socket;
     }
 
+    /**
+     * Serialize tags
+     *
+     * @param array $tags A list of tags to send to the server
+     *
+     * @return string A string containing a Datadog formatted tags
+     */
     protected function serializeTags(array $tags): string
     {
         if (! is_array($tags) || count($tags) === 0) {

--- a/src/Laravel/Provider/StatsdServiceProvider.php
+++ b/src/Laravel/Provider/StatsdServiceProvider.php
@@ -45,6 +45,10 @@ class StatsdServiceProvider extends ServiceProvider
                 $options = [];
                 $config  = $app['config'];
 
+                if (!empty($config['statsd.scheme'])) {
+                    $options['scheme'] = $config['statsd.scheme'];
+                }
+
                 if (isset($config['statsd.host'])) {
                     $options['host'] = $config['statsd.host'];
                 }

--- a/src/Laravel5/Provider/StatsdServiceProvider.php
+++ b/src/Laravel5/Provider/StatsdServiceProvider.php
@@ -53,6 +53,10 @@ class StatsdServiceProvider extends ServiceProvider
                 $options = [];
                 $config  = $app['config'];
 
+                if (!empty($config['statsd.scheme'])) {
+                    $options['scheme'] = $config['statsd.scheme'];
+                }
+
                 if (isset($config['statsd.host'])) {
                     $options['host'] = $config['statsd.host'];
                 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -6,13 +6,19 @@ use League\StatsD\Client;
 
 class ClientTest extends TestCase
 {
+    /**
+     * Creates instances of Client
+     */
     public function testNewInstance()
     {
         $client = new Client();
         $this->assertInstanceOf(Client::class, $client);
-        $this->assertMatchesRegularExpression('/^StatsD\\\Client::\[[a-zA-Z0-9]+\]$/', (string) $client);
+        $this->assertMatchesRegularExpression('/^StatsD\\\Client::\[[a-zA-Z0-9]+]$/', (string) $client);
     }
 
+    /**
+     * Returns the same instance for the same name
+     */
     public function testStaticInstance()
     {
         $client1 = Client::instance('instance1');
@@ -20,7 +26,21 @@ class ClientTest extends TestCase
         $client2 = Client::instance('instance2');
         $client3 = Client::instance('instance1');
         $this->assertEquals('StatsD\Client::[instance2]', (string) $client2);
-        $this->assertFalse((string) $client1 === (string) $client2);
-        $this->assertTrue((string) $client1 === (string) $client3);
+        $this->assertFalse($client1 === $client2);
+        $this->assertTrue($client1 === $client3);
+    }
+
+    /**
+     * Can forget only specified instance
+     */
+    public function testForgetStaticInstance()
+    {
+        $client1 = Client::instance('instance1');
+        $client2 = Client::instance('instance2');
+        Client::forget('instance1');
+        $client3 = Client::instance('instance1');
+        $client4 = Client::instance('instance2');
+        $this->assertFalse($client1 === $client3);
+        $this->assertTrue($client2 === $client4);
     }
 }

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -66,7 +66,6 @@ class ConfigurationTest extends TestCase
         $this->assertEquals($this->client->getPort(), 8125);
     }
 
-
     /**
      * Valid Port
      */
@@ -76,5 +75,82 @@ class ConfigurationTest extends TestCase
             'port' => 1234
         ]);
         $this->assertEquals($this->client->getPort(), 1234);
+    }
+
+    /**
+     * Default Scheme
+     */
+    public function testDefaultScheme()
+    {
+        $this->assertEquals($this->client->getScheme(), 'udp');
+    }
+
+    /**
+     * Test that user can configure TCP scheme
+     */
+    public function testTcpScheme()
+    {
+        $this->client->configure([
+            'scheme' => 'tcp'
+        ]);
+        $this->assertEquals($this->client->getScheme(), 'tcp');
+    }
+
+    /**
+     * Test that user can configure UDP scheme
+     */
+    public function testUdpScheme()
+    {
+        $this->client->configure([
+            'scheme' => 'tcp'
+        ]);
+        $this->client->configure([
+            'scheme' => 'udp'
+        ]);
+        $this->assertEquals($this->client->getScheme(), 'udp');
+    }
+
+    /**
+     * Test that user can configure scheme in any case
+     */
+    public function testSchemeToLower()
+    {
+        $this->client->configure([
+            'scheme' => 'TCP'
+        ]);
+        $this->assertEquals($this->client->getScheme(), 'tcp');
+    }
+
+    /**
+     * Only strings are acceptable schemes
+     */
+    public function testIntegerScheme()
+    {
+        $this->expectException(ConfigurationException::class);
+        $this->client->configure([
+            'scheme' => 6
+        ]);
+    }
+
+    /**
+     * Unsupported schemes are not acceptable
+     */
+    public function testUnsupportedScheme()
+    {
+        $this->expectException(ConfigurationException::class);
+        $this->client->configure([
+            'scheme' => 'http'
+        ]);
+    }
+
+    /**
+     * Empty scheme is not acceptable
+     */
+    public function testEmptyScheme()
+    {
+        $this->expectException(ConfigurationException::class);
+        $this->client->configure([
+            'scheme' => ''
+        ]);
     }
 }

--- a/tests/TcpTest.php
+++ b/tests/TcpTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace League\StatsD\Test;
+
+class TcpTest extends TcpTestCase
+{
+    public function testEachMetricMustBeTerminatedByTheNewLineCharacter()
+    {
+        $this->client->timing('test_metric', 123);
+        $this->assertEquals("test_metric:123|ms\n", $this->client->getLastMessage());
+    }
+
+    public function testErrorMessageContainsCorrectScheme()
+    {
+        $this->client->configure([
+            'host' => 'hostdoesnotexiststalleverlol.stupidtld',
+            'port' => 8125,
+            'throwConnectionExceptions' => false
+        ]);
+        $handlerInvoked = false;
+
+        $testCase = $this;
+
+        set_error_handler(
+            function ($errno, $errstr, $errfile) use ($testCase, &$handlerInvoked) {
+                $handlerInvoked = true;
+                $testCase->assertStringContainsString(
+                    'StatsD server connection failed (tcp://hostdoesnotexiststalleverlol.stupidtld:8125)',
+                    $errstr
+                );
+            },
+            E_USER_WARNING
+        );
+
+        $this->client->increment('test');
+        restore_error_handler();
+
+        $this->assertTrue($handlerInvoked);
+    }
+}

--- a/tests/TcpTestCase.php
+++ b/tests/TcpTestCase.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace League\StatsD\Test;
+
+use League\StatsD\Client;
+
+class TcpTestCase extends \PHPUnit\Framework\TestCase
+{
+    protected Client $client;
+
+    protected function setUp(): void
+    {
+        $tcpServerConfig = getenv('STATSD_TCP_ADDRESS') ?: '';
+        if (empty($tcpServerConfig)) {
+            $this->markTestSkipped("Can't test TCP support without configured tcp server");
+        }
+
+        $configParts = explode(':', $tcpServerConfig);
+        if (count($configParts) < 2) {
+            $this->markTestSkipped("Environment variable STATSD_TCP_ADDRESS should bi in format host:port");
+        }
+        $port = (int)array_pop($configParts);
+        $host = implode(':', $configParts); // in case of IPv6 address
+
+        $this->client = new Client();
+        $this->client->configure([
+            'scheme' => 'tcp',
+            'host' => $host,
+            'port' => $port,
+        ]);
+    }
+}

--- a/tests/TestClient.php
+++ b/tests/TestClient.php
@@ -8,4 +8,9 @@ class TestClient extends \League\StatsD\Client
     {
         return $this->timeout;
     }
+
+    public function getSocketProperty()
+    {
+        return $this->socket;
+    }
 }


### PR DESCRIPTION
Rarely somebody need that feature, but in case if does, here is support for TCP connections in a pull request.

UDP is great. It's fast, it's reliable in local connections and it even doesn't require to have server running.

But in case your StatsD server running on other machine and your network become flooded with packages (i.e. during DDoS attack), your packets will start to get lost and your metrics won't show you the real picture. You want get real count of unique IP addresses of clients. Attendance is falling, mean/percentile looks good, but site isn't going well.
That's the problem that I run into.

Of cause it would be better to run local instances of StatsD on each server. But it's also possible to switch on TCP.
You still need to set your NAT/firewall properly, cause no any authentication is used, and all your data goes in plane text thru the network.

As far as TCP connections take resources both from client and server, I added destructor and the ability to remove static instance, to free the connection. And because of destructor, magic __clone method is also appeared with a controversial decision.
As far as testing with a TCP scheme requires running TCP server and everyone have different workspace, I opted TCP tests with an STATSD_TCP_ADDRESS environment variable that should have 'host:port' of any TCP server (it could be any http-server as well, because we don't need to get any meaningful answer from the server, just an IP SYN and ACK packets). On linux systems you can use `nc -lk 127.0.0.1 8125` and set STATSD_TCP_ADDRESS to '127.0.0.1:8125' (IPv6 is also supported if needed).

Tested wit PHP 7.4, 8.0 and 8.1.
Laravel integration updated.
No breaking changes involved. Only minor changes:
* New 'scheme' config that can be skipped.
* New 'STATSD_SCHEME' environmental variable for Laravel integration, that can be skipped or set to empty (but you can't pass empty value to configure function, for now it's forbidden but can be changed if needed).
* When you clone object it won't share the same resource anymore.
So it can be called ver 2.1.

I leave some minor phpDoc changer in separate commit, 'cause it's a controversial topic. Fell free tho throw them out or merge together.